### PR TITLE
Mind Trait Added

### DIFF
--- a/code/modules/jobs/job_types/captain.dm
+++ b/code/modules/jobs/job_types/captain.dm
@@ -21,6 +21,8 @@ Captain
 	access = list() 			//See get_access()
 	minimal_access = list() 	//See get_access()
 
+	mind_traits = list(TRAIT_CAPTAIN_METABOLISM)
+
 	blacklisted_quirks = list(/datum/quirk/mute, /datum/quirk/brainproblems, /datum/quirk/insanity)
 
 /datum/job/captain/get_access()


### PR DESCRIPTION
Mind Trait added to Captain role

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Updates Captain.dm with its own metabolism mind trait.

## Changelog
:cl:
add: mindtrait - metabolism
/:cl: